### PR TITLE
:recycle: (User Profile): Rewrote how user badges are displayed

### DIFF
--- a/src/app/profile/profile.module.ts
+++ b/src/app/profile/profile.module.ts
@@ -1,16 +1,13 @@
-
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { UserProfileComponent } from './user-profile/user-profile.component';
-import { RouterModule } from '@angular/router';
-import { routes } from './profile.routing';
-
-
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { UserProfileComponent } from "./user-profile/user-profile.component";
+import { RouterModule } from "@angular/router";
+import { routes } from "./profile.routing";
+import { FlexLayoutModule } from "@angular/flex-layout";
 
 @NgModule({
   declarations: [UserProfileComponent],
-  imports: [
-    CommonModule,RouterModule.forChild(routes)
-  ]
+  // TODO: Choose whether to add SharedModule or FlexLayoutModule
+  imports: [CommonModule, FlexLayoutModule, RouterModule.forChild(routes)]
 })
-export class ProfileModule { }
+export class ProfileModule {}

--- a/src/app/profile/user-profile/user-profile.component.html
+++ b/src/app/profile/user-profile/user-profile.component.html
@@ -1,5 +1,5 @@
 <header class="profile-header ">
-    <img src="https://via.placeholder.com/150" class="profile-image">
+    <img src="https://via.placeholder.com/150" class="profile-image" alt="Profile Picture">
 
     <section class="user-details" >
         <h1 class="user-header ">John Wick</h1>
@@ -11,10 +11,8 @@
     </section>
     <section>
         <h2>Community Badges</h2>
-        <section  class="mt-20" fxLayout="row" fxLayoutAlign="center">
-                <ng-container *ngFor="let image of mockImages; let first = first">
-                    <img [src]="image" [class.ml-32]="!first">
-                </ng-container>
+        <section  class="mt-20" fxLayout="row" fxLayoutAlign="start" fxLayoutGap="32px">
+            <img *ngFor="let image of mockImages" [src]="image" alt="badge">
         </section>
     </section>
 </header>


### PR DESCRIPTION
Removed helper class `ml-32` and used `fxLayoutGap` on container element instead, also removed `ng-container` since there's no point in using it with a single structural directive